### PR TITLE
Fix issue with splits.

### DIFF
--- a/snippet/src/main/java/com/microsoft/snippet/Snippet.java
+++ b/snippet/src/main/java/com/microsoft/snippet/Snippet.java
@@ -19,6 +19,7 @@ import com.microsoft.snippet.token.LogTokenState;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -492,6 +493,7 @@ public final class Snippet {
         private volatile LogTokenState mState;
         private long mLastSplitTimeCaptured = 0L;
         private List<Split> mSplitRecord;
+        private final AtomicInteger mSequenceNumber = new AtomicInteger(1);
 
         // To be called only through LogTokenPool. Should not be created through any other ways.
         protected LogToken() {
@@ -561,6 +563,8 @@ public final class Snippet {
             if (this.mSplitRecord != null) {
                 this.mSplitRecord.clear();
             }
+            this.mSequenceNumber.set(1);
+            this.mLastSplitTimeCaptured = 0L;
             this.mSplitRecord = null;
         }
 
@@ -614,11 +618,11 @@ public final class Snippet {
                 if (mLastSplitTimeCaptured == 0L) {  // Split called for the first time
                     // We use the token start time as the reference.
                     mLastSplitTimeCaptured = ToolBox.currentTime();
-                    newSplit = new Split(getStart(), mLastSplitTimeCaptured);
+                    newSplit = new Split(getStart(), mLastSplitTimeCaptured, mSequenceNumber.getAndIncrement());
                 } else {
                     // Here we use the last split time captured.
                     long currentTime = ToolBox.currentTime();
-                    newSplit = new Split(mLastSplitTimeCaptured, currentTime);
+                    newSplit = new Split(getStart(), mLastSplitTimeCaptured, mSequenceNumber.getAndIncrement());
                     mLastSplitTimeCaptured = currentTime;
                 }
             }

--- a/snippet/src/main/java/com/microsoft/snippet/Split.java
+++ b/snippet/src/main/java/com/microsoft/snippet/Split.java
@@ -1,8 +1,10 @@
+/*
+ * Copyright © Microsoft Corporation. All rights reserved.
+ */
+
 package com.microsoft.snippet;
 
 import androidx.annotation.RestrictTo;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Split is a sub section of code within a capture( a contiguous/non-contiguous section of code).
@@ -16,7 +18,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class Split {
 
-    private static final AtomicInteger SEQUENCE = new AtomicInteger(1);
     private final long mStarted;
     private final long mEnded;
     private final int mSequence;
@@ -24,10 +25,10 @@ public class Split {
 
     private String mInfo;
 
-    public Split(long start, long end) {
+    public Split(long start, long end, int seqNumber) {
         this.mStarted = start;
         this.mEnded = end;
-        this.mSequence = SEQUENCE.getAndIncrement();
+        this.mSequence = seqNumber;
     }
 
     public void setName(String name) {


### PR DESCRIPTION
State of split was managed internally. And when the LogToken was recycled, it was not resetting the split state.
Which lead to an issue where after token recycle, the split count was incremented from the previous value of split.

1. Count management moved to LogToken
2. Reset() not, resets the count too.

Thanks @gipartha for pointing this out!
